### PR TITLE
Add 'New Unit' button to units table

### DIFF
--- a/resources/js/pages/Admin/Units/Index.tsx
+++ b/resources/js/pages/Admin/Units/Index.tsx
@@ -159,6 +159,13 @@ export default function UnitsIndexPage({ units, filters, allUnits }: UnitsIndexP
                                 <Button onClick={handleSearch}>Search</Button>
                             </div>
 
+                            <div className="mb-4 flex justify-end">
+                                <Button onClick={openCreateModal}>
+                                    <Icon name="Plus" className="mr-2" />
+                                    New Unit
+                                </Button>
+                            </div>
+
                             <Table>
                                 <TableHeader>
                                     <TableRow>


### PR DESCRIPTION
This commit adds a 'New Unit' button to the top right side of the units table interface. The button triggers the same modal as the existing 'Create Unit' button for adding new units.