### PR TITLE
Fix: Use named export for InputError component

### DIFF
--- a/resources/js/components/input-error.tsx
+++ b/resources/js/components/input-error.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/lib/utils';
 import { type HTMLAttributes } from 'react';
 
-export default function InputError({ message, className = '', ...props }: HTMLAttributes<HTMLParagraphElement> & { message?: string }) {
+export function InputError({ message, className = '', ...props }: HTMLAttributes<HTMLParagraphElement> & { message?: string }) {
     return message ? (
         <p {...props} className={cn('text-sm text-red-600 dark:text-red-400', className)}>
             {message}


### PR DESCRIPTION
Changed the export method for the `InputError` component from default to named export (`export function InputError`).

This resolves the "Cannot resolve InputError" issue in `RubrikRemun/Index.tsx` by aligning the export with the existing named import statement and ensuring consistency with other components like `Pagination`.