### PR TITLE
Add role switcher dropdown to sidebar

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+use Spatie\Permission\Models\Role;
+use Illuminate\Validation\Rule;
+
+class UserController extends Controller
+{
+    public function switchRole(Request $request)
+    {
+        $user = Auth::user();
+        $validated = $request->validate([
+            'role' => ['required', 'string', Rule::in($user->getRoleNames())],
+        ]);
+
+        $newRoleName = $validated['role'];
+        $newRole = Role::findByName($newRoleName);
+
+        if ($newRole) {
+            $user->last_active_role_id = $newRole->id;
+            $user->save();
+        }
+
+        // It's generally good practice to redirect back after a POST request.
+        // Inertia will handle this by refreshing props.
+        return Redirect::back()->with('success', 'Role switched successfully.');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Spatie\Permission\Models\Role;
 use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
@@ -22,6 +23,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'last_active_role_id',
     ];
 
     /**
@@ -45,5 +47,13 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Get the user's last active role.
+     */
+    public function lastActiveRole()
+    {
+        return $this->belongsTo(Role::class, 'last_active_role_id');
     }
 }

--- a/database/migrations/2025_06_24_050000_add_last_active_role_id_to_users_table.php
+++ b/database/migrations/2025_06_24_050000_add_last_active_role_id_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('last_active_role_id')->nullable()->constrained('roles')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['last_active_role_id']);
+            $table->dropColumn('last_active_role_id');
+        });
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,9 +1,10 @@
 import { NavFooter } from '@/components/nav-footer';
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
-import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar'; // Removed SidebarGroup, SidebarGroupLabel
+import { RoleSwitcherDropdown } from '@/components/role-switcher-dropdown'; // Added
+import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavGroup, type NavItem } from '@/types';
-import { Link } from '@inertiajs/react'; // Removed usePage
+import { Link } from '@inertiajs/react';
 import { BookOpen, Database, Folder, LayoutGrid, ShieldCheck, Users } from 'lucide-react'; // Added Database icon
 import AppLogo from './app-logo';
 
@@ -108,8 +109,11 @@ export function AppSidebar() {
                 </SidebarMenu>
             </SidebarHeader>
 
-            <SidebarContent>
-                <NavMain groups={mainNavGroups} /> {/* Changed items to groups and mainNavItems to mainNavGroups */}
+            <SidebarContent className="flex flex-col gap-y-2">
+                <div className="px-3"> {/* Added padding for the dropdown */}
+                    <RoleSwitcherDropdown />
+                </div>
+                <NavMain groups={mainNavGroups} />
             </SidebarContent>
 
             <SidebarFooter>

--- a/resources/js/components/role-switcher-dropdown.tsx
+++ b/resources/js/components/role-switcher-dropdown.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { usePage, router } from '@inertiajs/react';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuLabel,
+    DropdownMenuRadioGroup,
+    DropdownMenuRadioItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button'; // Using Button for the trigger
+import { SharedData } from '@/types';
+import { ChevronsUpDown } from 'lucide-react'; // Icon for the dropdown trigger
+
+export function RoleSwitcherDropdown() {
+    const { auth } = usePage<SharedData>().props;
+    const { userRoles, currentRole, user } = auth;
+
+    const [selectedRole, setSelectedRole] = React.useState<string | null>(currentRole);
+
+    React.useEffect(() => {
+        setSelectedRole(currentRole);
+    }, [currentRole]);
+
+    const handleRoleChange = (newRole: string) => {
+        if (newRole !== selectedRole) {
+            router.post(
+                route('user.switch-role'),
+                { role: newRole },
+                {
+                    onSuccess: () => {
+                        setSelectedRole(newRole);
+                        // Potentially show a toast notification if desired
+                    },
+                    onError: (errors) => {
+                        console.error('Error switching role:', errors);
+                        // Handle error, maybe show a notification
+                    },
+                },
+            );
+        }
+    };
+
+    if (!user || !userRoles || userRoles.length === 0) {
+        return null; // Don't render if no user, no roles, or roles array is empty
+    }
+
+    // If user has only one role, or no roles, don't show the dropdown.
+    // Or, if currentRole is not set (e.g. new user), don't show.
+    if (userRoles.length <= 1 || !currentRole) {
+        return (
+            <div className="px-3 py-2 text-sm font-medium text-muted-foreground">
+                Role: {currentRole || 'N/A'}
+            </div>
+        );
+    }
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    variant="outline"
+                    className="w-full flex items-center justify-between px-3 py-2 text-sm"
+                >
+                    <span className="truncate">
+                        Role: {selectedRole || 'Select Role'}
+                    </span>
+                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-56" align="end">
+                <DropdownMenuLabel>Switch Role</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuRadioGroup value={selectedRole || ''} onValueChange={handleRoleChange}>
+                    {userRoles.map((roleName) => (
+                        <DropdownMenuRadioItem key={roleName} value={roleName}>
+                            {roleName}
+                        </DropdownMenuRadioItem>
+                    ))}
+                </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -3,6 +3,8 @@ import type { Config } from 'ziggy-js';
 
 export interface Auth {
     user: User;
+    userRoles: string[];
+    currentRole: string | null; // Can be null if not set or user has no roles
 }
 
 export interface BreadcrumbItem {

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Admin\PegawaiController; // Added
 use App\Http\Controllers\Admin\JabatanController;
 use App\Http\Controllers\RubrikKategoriController; // Added
 use App\Http\Controllers\RubrikRemunController; // Added
+use App\Http\Controllers\UserController; // Added for role switching
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -21,6 +22,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', function () {
         return Inertia::render('dashboard');
     })->name('dashboard');
+
+    Route::post('/user/switch-role', [UserController::class, 'switchRole'])->name('user.switch-role');
 
     Route::name('admin.')->prefix('admin')->group(function () {
         Route::resource('roles', RoleController::class)->except(['show']);


### PR DESCRIPTION
This feature allows users with multiple roles to switch between them.

Backend:
- Added `last_active_role_id` to the `users` table to store the user's preferred role.
- Updated `HandleInertiaRequests` middleware to pass user's roles and current active role to the frontend.
- Created a `UserController` with a `switchRole` method to handle role changes and persist the selection.

Frontend:
- Updated TypeScript types for `Auth` props.
- Created a `RoleSwitcherDropdown` React component using existing UI elements.
  - Displays current role and lists available roles for the user.
  - Handles POST request to backend for switching roles.
  - Gracefully handles users with single or no roles by displaying text instead of a dropdown.
- Integrated the dropdown into the `AppSidebar` component.

Note: Database migration for `last_active_role_id` needs to be run manually.